### PR TITLE
Increase the fetch issues to 300

### DIFF
--- a/lib/facade.js
+++ b/lib/facade.js
@@ -35,7 +35,7 @@ Facade.prototype.fetchFromGitHub = function() {
   return new Promise((fullfill, reject) => {
     var client = github.client();
     var ghrepo = client.repo(this.repositoryName);
-    ghrepo.issues(function(err, issues) {
+    ghrepo.issues(1, 300, function(err, issues) {
       if(err) {
         reject({
           message: `Repository ${self.repositoryName} not found`,


### PR DESCRIPTION
Related to #31.
Not perfect, it probably should iterate or declare the limit somehow, but better than nothing.
If not specified, it fetches 30 issues by default